### PR TITLE
fix(node): Fix proxy resolution logic running from node context

### DIFF
--- a/oni.package.json
+++ b/oni.package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@onivim/vscode-exthost",
-	"version": "1.52.1000",
+	"version": "1.52.1001",
 	"distro": "df7748995d690f8d2022d96c367ead3d686833ff",
 	"author": {
 		"name": "Outrun Labs, LLC"


### PR DESCRIPTION
Because this code brings in `vscode-proxy-agent`, and `agent-base`, we  hit the same issue here https://github.com/microsoft/vscode/issues/93167 - which manifests in Onivim in issues like: https://github.com/onivim/oni2/issues/2981

This works around the issue by only using the 2-argument overload for `https`/`http`.request`.